### PR TITLE
Fix macos build error in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew update
-          brew install bdw-gc
+          brew install bdw-gc gnu-sed
+          echo PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
       - name: Test plugin
         uses: asdf-vm/actions/plugin-test@v2
         with:


### PR DESCRIPTION
Summary
-------

Fixes an error during the guile `make install` target which requires GNU `sed`. Usually the error manifests itself as the following error:

```
sed: -e: No such file or directory
```

Context
-------

- https://www.mail-archive.com/bug-guile@gnu.org/msg10338.html

There are differences between GNU and BSD `sed`. The upstream, GNU Guile `make install` target assumes that GNU `sed` is on the path, but for MacOS hosts, this is not the case. This makes sure that the GNU `sed` package is installed and on the path of MacOS hosts in CI. 