### PR TITLE
Fix macos hombrew-cask tap fetching ci failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,12 @@ jobs:
       - name: Install dependencies
         if: matrix.os == 'ubuntu-latest'
         run: |
-          sudo apt-get update
           sudo apt-get install -y \
             libgc-dev \
             libunistring-dev
       - name: Install dependencies
         if: matrix.os == 'macos-latest'
         run: |
-          brew update
           brew install bdw-gc gnu-sed
           export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
       - name: Test plugin


### PR DESCRIPTION
Schedule CI builds for MacOS started failing this week. An example failure [here](https://github.com/indiebrain/asdf-guile/actions/runs/5440508949/jobs/9929899534):

```
  brew update
  brew install bdw-gc gnu-sed
  export PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
  shell: /bin/bash -e {0}
error: Could not read 7e05915b105f410bd766fd5e2d376c95a7605ace
fatal: revision walk setup failed
error: https://github.com/Homebrew/homebrew-cask did not send all necessary objects
```